### PR TITLE
Cope with deleted users

### DIFF
--- a/users_field.php
+++ b/users_field.php
@@ -405,18 +405,19 @@ class Users_field extends acf_Field
 			foreach($value as $k => $v)
 			{
 				$user_data = get_userdata($v);
-				$value[$k] = array();
-				$value[$k]['ID'] = $v;
-				$value[$k]['user_firstname'] = $user_data->user_firstname;
-				$value[$k]['user_lastname'] = $user_data->user_lastname;
-				$value[$k]['nickname'] = $user_data->nickname;
-				$value[$k]['user_nicename'] = $user_data->user_nicename;
-				$value[$k]['display_name'] = $user_data->display_name;
-				$value[$k]['user_email'] = $user_data->user_email;
-				$value[$k]['user_url'] = $user_data->user_url;
-				$value[$k]['user_registered'] = $user_data->user_registered;
-				$value[$k]['user_description'] = $user_data->user_description;
-
+				if(isset($user_data) && is_object($user_data)){
+					$value[$k] = array();
+					$value[$k]['ID'] = $v;
+					$value[$k]['user_firstname'] = $user_data->user_firstname;
+					$value[$k]['user_lastname'] = $user_data->user_lastname;
+					$value[$k]['nickname'] = $user_data->nickname;
+					$value[$k]['user_nicename'] = $user_data->user_nicename;
+					$value[$k]['display_name'] = $user_data->display_name;
+					$value[$k]['user_email'] = $user_data->user_email;
+					$value[$k]['user_url'] = $user_data->user_url;
+					$value[$k]['user_registered'] = $user_data->user_registered;
+					$value[$k]['user_description'] = $user_data->user_description;
+				}
 			}
 		}
 		else


### PR DESCRIPTION
If the user has been deleted since they were selected by ACF then we get a bunch of errors.  This change checks they exist before trying to use them.

Calling code then has to cope with the missing data e.g.

```
    $users = get_field('users');

    foreach($users as $user){

            if(!isset($user) || $user == null || !is_array($user)){
              continue; // Or print something saying the user has been deleted
            }

            // do something with the user
    }
```
